### PR TITLE
add tqdm to requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ setup(
     install_requires=[
         'numpy >=1.12',
         'jax',
+        'jaxlib',
+        'tqdm'
     ],
     url='https://github.com/google-research/reverse-engineering-neural-networks',
     license='Apache-2.0',


### PR DESCRIPTION
Adds tqdm and jaxlib as requirements in setup.py.  Without this, import was failing.