### PR TITLE
Initial addition of plane interpolation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/pre-commit/mirrors-yapf
+    rev: 'v0.29.0'
+    hooks:
+    -   id: yapf

--- a/renn/analysis_utils.py
+++ b/renn/analysis_utils.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Utilities for analysis."""
 
 from collections import defaultdict
@@ -19,6 +18,7 @@ from itertools import product
 import numpy as np
 
 __all__ = ['pseudogrid']
+
 
 def pseudogrid(coordinates, dimension):
   """Constructs a pseudogrid
@@ -56,10 +56,10 @@ def pseudogrid(coordinates, dimension):
   if max_specified_dim > 32:
     raise NotImplementedError('Maximum specified dimension cannot exceed 32')
 
-  points = np.meshgrid(*[all_coordinates[i] for i in range(max_specified_dim+1)])
-  points = np.stack(points).reshape(max_specified_dim+1, -1).T
+  points = np.meshgrid(
+      *[all_coordinates[i] for i in range(max_specified_dim + 1)])
+  points = np.stack(points).reshape(max_specified_dim + 1, -1).T
 
-  padding = np.zeros((points.shape[0],
-                      dimension - max_specified_dim - 1))
+  padding = np.zeros((points.shape[0], dimension - max_specified_dim - 1))
 
   return np.concatenate((points, padding), axis=1)

--- a/renn/analysis_utils.py
+++ b/renn/analysis_utils.py
@@ -1,0 +1,69 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for analysis."""
+
+from collections import defaultdict
+from itertools import product
+import numpy as np
+
+__all__ = ['pseudogrid']
+
+def pseudogrid(coordinates, dimension):
+  """Constructs a pseudogrid
+    ('pseudo' in that it is not necessarily evenly-spaced)
+    of points in 'dimension'-dimension space
+    from the specified coordinates.
+
+    Arguments:
+    coordinates: a mapping between dimensions and
+                  coordinates in those dimensions
+    dimension: number of dimensions
+
+    For all dimensions that are not specified, the coordinate
+    is taken to be 0.
+
+    Example:
+      if coordinates = {0: [0, 1, 2],
+                        2: [1]},
+      and dimension = 4, the coordinates in dimensions
+      1 and 3 will be taken as [0], yielding the effective
+      coordinate-dictionary
+        coordinates = {0: [0,1,2],
+                       1: [0],
+                       2: [1],
+                       3: [0]}
+      Then the resulting pseudogrid will be constructed as:
+        [[0,0,1,0], [1,0,1,0], [2,0,1,0]]
+  """
+
+  all_coordinates = defaultdict(lambda: np.array(0.0))
+  all_coordinates.update(coordinates)
+
+  max_specified_dim = max(coordinates.keys())
+
+  if max_specified_dim > 32:
+    raise NotImplementedError('Maximum specified dimension cannot exceed 32')
+
+  points = np.meshgrid(*[all_coordinates[i] for i in range(max_specified_dim+1)])
+  points = np.stack(points).reshape(max_specified_dim+1, -1).T
+
+  padding = np.zeros((points.shape[0],
+                      dimension - max_specified_dimension - 1))
+
+  return np.concatenate((points, padding), axis=1
+
+  points = np.meshgrid(*[all_coordinates[i] for i in range(dimension)])
+  return np.dstack(points).reshape(-1, dimension)
+

--- a/renn/analysis_utils.py
+++ b/renn/analysis_utils.py
@@ -60,10 +60,6 @@ def pseudogrid(coordinates, dimension):
   points = np.stack(points).reshape(max_specified_dim+1, -1).T
 
   padding = np.zeros((points.shape[0],
-                      dimension - max_specified_dimension - 1))
+                      dimension - max_specified_dim - 1))
 
-  return np.concatenate((points, padding), axis=1
-
-  points = np.meshgrid(*[all_coordinates[i] for i in range(dimension)])
-  return np.dstack(points).reshape(-1, dimension)
-
+  return np.concatenate((points, padding), axis=1)

--- a/tests/au_test.py
+++ b/tests/au_test.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for analysis utilities."""
 
 import jax.numpy as jnp
@@ -21,12 +20,13 @@ import pytest
 
 from renn import analysis_utils as au
 
+
 def test_pseudogrid():
   """ Tests for the pseudogrid function """
 
   # Test shape correctness
   dimensions = [10, 23, 40]
-  pts = [[10,50,23], [24,12], [7,8,9,12]]
+  pts = [[10, 50, 23], [24, 12], [7, 8, 9, 12]]
 
   for dimension in dimensions:
     for n_pts in pts:
@@ -36,13 +36,10 @@ def test_pseudogrid():
       assert pseudogrid_1.shape == (np.product(n_pts), dimension)
 
   # Test particular coordinates
-  coordinates = {0: [0, 1, 2],
-                 1: [1]}
+  coordinates = {0: [0, 1, 2], 1: [1]}
   dimension = 4
   pseudogrid_2 = au.pseudogrid(coordinates, dimension)
 
-  ideal = np.array([[0,1,0,0],
-                               [1,1,0,0],
-                               [2,1,0,0]])
+  ideal = np.array([[0, 1, 0, 0], [1, 1, 0, 0], [2, 1, 0, 0]])
 
   assert np.array_equal(ideal, pseudogrid_2)

--- a/tests/au_test.py
+++ b/tests/au_test.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for analysis utilities."""
+
+import jax.numpy as jnp
+import numpy as np
+
+import pytest
+
+from renn import analysis_utils as au
+
+def test_pseudogrid():
+  """ Tests for the pseudogrid function """
+
+  # Test shape correctness
+  dimensions = [10, 23, 40]
+  pts = [[10,50,23], [24,12], [7,8,9,12]]
+
+  for dimension in dimensions:
+    for n_pts in pts:
+      coordinates = {i: np.linspace(-1, 1, n_pts[i]) for i in range(len(n_pts))}
+      pseudogrid_1 = au.pseudogrid(coordinates, dimension)
+
+      assert pseudogrid_1.shape == (np.product(n_pts), dimension)
+
+  # Test particular coordinates
+  coordinates = {0: [0, 1, 2],
+                 1: [1]}
+  dimension = 4
+  pseudogrid_2 = au.pseudogrid(coordinates, dimension)
+
+  ideal = np.array([[0,1,0,0],
+                               [1,1,0,0],
+                               [2,1,0,0]])
+
+  assert np.array_equal(ideal, pseudogrid_2)


### PR DESCRIPTION
Adds a utility for interpolating a plane-like set of points in arbitrary dimensions.

Unit Tests:
`tests/au_test.py` test for the following: shape correctness, and a couple particular examples