### PR TITLE
add a max_len attribute to synthetic data

### DIFF
--- a/renn/data/synthetic.py
+++ b/renn/data/synthetic.py
@@ -26,7 +26,9 @@ def constant_sampler(value):
   def sample(num_samples):
     return np.full((num_samples,), value)
 
-  return sample
+  max_length = value
+
+  return sample, max_length
 
 
 def uniform_sampler(min_val, max_val):
@@ -36,7 +38,9 @@ def uniform_sampler(min_val, max_val):
   def sample(num_samples):
     return np.random.randint(min_val, max_val + 1, size=(num_samples,))
 
-  return sample
+  max_length = max_val
+
+  return sample, max_length
 
 
 def build_vocab(valences=None, num_classes=3):
@@ -84,7 +88,7 @@ class Unordered:
     self.batch_size = batch_size
 
     if length_sampler in SAMPLERS.keys():
-      self.sampler = SAMPLERS[length_sampler](**sampler_params)
+      self.sampler, self.max_len = SAMPLERS[length_sampler](**sampler_params)
     else:
       raise ValueError(f'length_sampler must be one of {SAMPLERS.keys()}')
 

--- a/tests/synthetic_test.py
+++ b/tests/synthetic_test.py
@@ -24,7 +24,8 @@ def test_constant_sampler():
   sample_nums = [10, 15, 16, 18]
 
   for val in constant_values:
-    s = synthetic.constant_sampler(value=val)
+    s, max_length = synthetic.constant_sampler(value=val)
+    assert max_length == val
     for num in sample_nums:
       assert len(s(num)) == num
       assert len(set(s(num))) == 1
@@ -39,7 +40,9 @@ def test_uniform_sampler():
   sample_nums = [10, 15, 16, 18]
 
   for interval in intervals:
-    s = synthetic.uniform_sampler(min_val=interval[0], max_val=interval[1])
+    s, max_length = synthetic.uniform_sampler(min_val=interval[0],
+                                              max_val=interval[1])
+    assert max_length == interval[1]
     for num in sample_nums:
       samples = s(num)
       assert len(samples) == num


### PR DESCRIPTION
When initializing an rnn, it's useful to know the maximum possible length of the sequence.  This PR adds that functionality to the synthetic dataset, which was missing before.