### PR TITLE
adds squash to analysis_utils

### DIFF
--- a/renn/analysis_utils.py
+++ b/renn/analysis_utils.py
@@ -63,3 +63,16 @@ def pseudogrid(coordinates, dimension):
   padding = np.zeros((points.shape[0], dimension - max_specified_dim - 1))
 
   return np.concatenate((points, padding), axis=1)
+
+
+def squash(points, transform_object, n_dims_keep):
+  """ Given a set of points and a transform object,
+  transform the points using the transform, squash all
+  dimensions after the first n_dims_keep dimensions to
+  zero, and then transforms back to the original space
+  """
+
+  transformed = transform_object.transform(points)
+  transformed[:, n_dims_keep:] = 0.0
+  squashed = transform_object.inverse_transform(transformed)
+  return squashed


### PR DESCRIPTION
It's useful to have a utility that squashes points along dimensions in transformed space (i.e. after doing PCA).  This allows us to see how much of the dynamics is captured by the low-dimensional projection.  This PR adds that function (`squash()`) to `analysis_utils.py`